### PR TITLE
Update README to include check

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Add in your `Rakefile` this lines:
 
 ```ruby
 require 'knapsack'
-Knapsack.load_tasks
+Knapsack.load_tasks if defined? Knapsack 
 ```
 
 Generate time execution report for your test files. Run below command on one of your CI nodes.


### PR DESCRIPTION
Add if defined? check to README to allow use of rake in non-test mode

---

I imagine the common use case is to require knapsack in only test env with bundler. If that's the case, following the docs will then break the use of 'rake' in any env other then test.
