### PR TITLE
Raise error when CI_NODE_INDEX >= CI_NODE_TOTAL

### DIFF
--- a/lib/knapsack/distributors/base_distributor.rb
+++ b/lib/knapsack/distributors/base_distributor.rb
@@ -8,6 +8,10 @@ module Knapsack
         @test_file_pattern = args[:test_file_pattern] || raise('Missing test_file_pattern')
         @ci_node_total = args[:ci_node_total] || raise('Missing ci_node_total')
         @ci_node_index = args[:ci_node_index] || raise('Missing ci_node_index')
+
+        if ci_node_index >= ci_node_total
+          raise('Node indexes are 0-based. Can\'t be higher or equal to the total number of nodes.')
+        end
       end
 
       def ci_node_total

--- a/spec/knapsack/distributors/base_distributor_spec.rb
+++ b/spec/knapsack/distributors/base_distributor_spec.rb
@@ -49,6 +49,14 @@ describe Knapsack::Distributors::BaseDistributor do
       let(:custom_args) { { ci_node_index: nil } }
       it { expect { subject }.to raise_error('Missing ci_node_index') }
     end
+
+    context 'when ci_node_index is equal or higher than ci_node_total' do
+      let(:custom_args) { { ci_node_index: 1, ci_node_total: 1 } }
+      it {
+        expect { subject }.to raise_error('Node indexes are 0-based. Can\'t ' +
+                             'be higher or equal to the total number of nodes.')
+      }
+    end
   end
 
   describe '#tests_for_current_node' do


### PR DESCRIPTION
Hey, thanks for the great work on this! Very helpful.

I was just bit by this issue: when the `CI_NODE_INDEX` is equal or higher than `CI_NODE_TOTAL` knapsack blows up in a non-obvious way and the user may not be aware of what is causing the issue. I added a sanity check for this on BaseDistributor.

Hope you find this useful.