### PR TITLE
adding support for Buildkite ENV variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,6 +305,30 @@ Knapsack supports semaphoreapp ENVs `SEMAPHORE_THREAD_COUNT` and `SEMAPHORE_CURR
 
 Tests will be split across threads.
 
+### Info for buildkite.com users
+
+#### Step 1
+
+For the first time run all tests at once with enabled report generator. Run the following commands locally:
+
+    # Step for RSpec
+    KNAPSACK_GENERATE_REPORT=true bundle exec rspec spec
+
+    # Step for Cucumber
+    KNAPSACK_GENERATE_REPORT=true bundle exec cucumber features
+
+After tests pass your should copy knapsack json report which is rendered at the end of rspec/cucumber results. Save it into your repository as `knapsack_rspec_report.json` or `knapsack_cucumber_report.json` file and commit.
+
+#### Step 2
+
+Knapsack supports buildkite ENVs `BUILDKITE_PARALLEL_JOB_COUNT` and `BUILDKITE_PARALLEL_JOB`. The only thing you need to do is to configure the parallelism parameter in your build step and run the appropiate command in your build
+
+    # Step for RSpec
+    bundle exec rake knapsack:rspec
+
+    # Step for Cucumber
+    bundle exec rake knapsack:cucumber
+
 ## Gem tests
 
 ### Spec

--- a/lib/knapsack/config/env.rb
+++ b/lib/knapsack/config/env.rb
@@ -7,11 +7,11 @@ module Knapsack
         end
 
         def ci_node_total
-          ENV['CI_NODE_TOTAL'] || ENV['CIRCLE_NODE_TOTAL'] || ENV['SEMAPHORE_THREAD_COUNT'] || 1
+          ENV['CI_NODE_TOTAL'] || ENV['CIRCLE_NODE_TOTAL'] || ENV['SEMAPHORE_THREAD_COUNT'] || ENV['BUILDKITE_PARALLEL_JOB_COUNT'] || 1
         end
 
         def ci_node_index
-          ENV['CI_NODE_INDEX'] || ENV['CIRCLE_NODE_INDEX'] || semaphore_current_thread || 0
+          ENV['CI_NODE_INDEX'] || ENV['CIRCLE_NODE_INDEX'] || semaphore_current_thread || ENV['BUILDKITE_PARALLEL_JOB'] || 0
         end
 
         def test_file_pattern

--- a/spec/knapsack/config/env_spec.rb
+++ b/spec/knapsack/config/env_spec.rb
@@ -31,6 +31,11 @@ describe Knapsack::Config::Env do
         before { stub_const("ENV", { 'SEMAPHORE_THREAD_COUNT' => 3 }) }
         it { should eql 3 }
       end
+
+      context 'when BUILDKITE_PARALLEL_JOB_COUNT has value' do
+        before { stub_const("ENV", { 'BUILDKITE_PARALLEL_JOB_COUNT' => 4 }) }
+        it { should eql 4 }
+      end
     end
 
     context "when ENV doesn't exist" do
@@ -55,6 +60,11 @@ describe Knapsack::Config::Env do
       context 'when SEMAPHORE_CURRENT_THREAD has value' do
         before { stub_const("ENV", { 'SEMAPHORE_CURRENT_THREAD' => 1 }) }
         it { should eql 0 }
+      end
+
+      context 'when BUILDKITE_PARALLEL_JOB has value' do
+        before { stub_const("ENV", { 'BUILDKITE_PARALLEL_JOB' => 2 }) }
+        it { should eql 2 }
       end
     end
 


### PR DESCRIPTION
Recently [Buildkite](https://buildkite.com) added support for parallel jobs. This commit adds support for their provided ENV variables.