### PR TITLE
Add support for Turnip features

### DIFF
--- a/lib/knapsack/adapters/rspec_adapter.rb
+++ b/lib/knapsack/adapters/rspec_adapter.rb
@@ -45,9 +45,12 @@ module Knapsack
       end
 
       def self.test_path(example_group)
-        until example_group[:parent_example_group].nil?
-          example_group = example_group[:parent_example_group]
+        unless example_group[:turnip]
+          until example_group[:parent_example_group].nil?
+            example_group = example_group[:parent_example_group]
+          end
         end
+
         example_group[:file_path]
       end
     end

--- a/spec/knapsack/adapters/rspec_adapter_spec.rb
+++ b/spec/knapsack/adapters/rspec_adapter_spec.rb
@@ -94,5 +94,21 @@ describe Knapsack::Adapters::RspecAdapter do
     subject { described_class.test_path(current_example_metadata) }
 
     it { should eql 'a_spec.rb' }
+
+    context 'with turnip features' do
+      let(:current_example_metadata) do
+        {
+          file_path: "./spec/features/logging_in.feature",
+          turnip: true,
+          parent_example_group: {
+            file_path: "gems/turnip-1.2.4/lib/turnip/rspec.rb",
+          }
+        }
+      end
+
+      subject { described_class.test_path(current_example_metadata) }
+
+      it { should eql './spec/features/logging_in.feature' }
+    end
   end
 end


### PR DESCRIPTION
Turnip features are ran using the rspec runner and add "turnip: true" to
the example's metadata.  The "parent_example_group" will be turnip's
rspec extension, so to get the actual example file we want to stay at
the first level.

Fixes #18