### PR TITLE
Add knapsack binary

### DIFF
--- a/bin/knapsack
+++ b/bin/knapsack
@@ -1,0 +1,9 @@
+#!/usr/bin/env ruby
+
+require "knapsack"
+
+runner = ARGV[0]
+arguments = ARGV[1]
+
+system("bundle exec rake \"knapsack:#{runner}[#{arguments}]\"")
+exit($?.exitstatus)


### PR DESCRIPTION
Artur, thanks for the great work with Knapsack.

I'm interested if you're open to including the `knapsack` executable? Let me explain my motivation. I did some experimentation with Knapsack where I didn't use Knapsack to generate RSpec report. Instead, I generated the report from some other reports that I collect about specs. Then I used the manually built Knapsack report to run specs in parallel.

In this setup, Knapsack doesn't need to be included in the Gemfile. Instead, I can install Knapsack globally on the build machine and reuse it for all projects that I have. Do you think this can be interesting to a wider audience?

The PR implementation might not be the best, but it illustrates the idea. I can install gem globally and execute RSpec with `knapsack rspec`.

What do you think about this? Thanks.