### PR TITLE
Add knapsack binary

### DIFF
--- a/bin/knapsack
+++ b/bin/knapsack
@@ -1,0 +1,11 @@
+#!/usr/bin/env ruby
+
+require "knapsack"
+
+runner = ARGV[0]
+arguments = ARGV[1]
+
+case runner
+when "rspec"
+  Knapsack::Runners::RSpecRunner.run(arguments)
+end

--- a/lib/knapsack.rb
+++ b/lib/knapsack.rb
@@ -16,6 +16,7 @@ require_relative 'knapsack/adapters/base_adapter'
 require_relative 'knapsack/adapters/rspec_adapter'
 require_relative 'knapsack/adapters/cucumber_adapter'
 require_relative 'knapsack/adapters/minitest_adapter'
+require_relative 'knapsack/runners/rspec_runner'
 
 module Knapsack
   class << self

--- a/lib/knapsack/runners/rspec_runner.rb
+++ b/lib/knapsack/runners/rspec_runner.rb
@@ -1,0 +1,23 @@
+module Knapsack
+  module Runners
+    class RSpecRunner
+      def self.run(args)
+        allocator = Knapsack::AllocatorBuilder.new(Knapsack::Adapters::RspecAdapter).allocator
+
+        puts
+        puts 'Report specs:'
+        puts allocator.report_node_tests
+        puts
+        puts 'Leftover specs:'
+        puts allocator.leftover_node_tests
+        puts
+
+        cmd = %Q[bundle exec rspec #{args} --default-path #{allocator.test_dir} -- #{allocator.stringify_node_tests}]
+
+        system(cmd)
+        exit($?.exitstatus)
+
+      end
+    end
+  end
+end

--- a/lib/tasks/knapsack_rspec.rake
+++ b/lib/tasks/knapsack_rspec.rake
@@ -2,19 +2,6 @@ require 'knapsack'
 
 namespace :knapsack do
   task :rspec, [:rspec_args] do |_, args|
-    allocator = Knapsack::AllocatorBuilder.new(Knapsack::Adapters::RspecAdapter).allocator
-
-    puts
-    puts 'Report specs:'
-    puts allocator.report_node_tests
-    puts
-    puts 'Leftover specs:'
-    puts allocator.leftover_node_tests
-    puts
-
-    cmd = %Q[bundle exec rspec #{args[:rspec_args]} --default-path #{allocator.test_dir} -- #{allocator.stringify_node_tests}]
-
-    system(cmd)
-    exit($?.exitstatus)
+    Knapsack::Runners::RSpecRunner.run(args[:rspec_args])
   end
 end


### PR DESCRIPTION
Artur, thanks for the great work with Knapsack.

I'm interested if you're open to including the knapsack executable? Let me explain my motivation. I did some experimentation with Knapsack where I didn't use Knapsack to generate RSpec report. Instead, I generated the report from some other reports that I collect about specs. Then I used the manually built Knapsack report to run specs in parallel.

In this setup, Knapsack doesn't need to be included in the Gemfile. Instead, I can install Knapsack globally on the build machine and reuse it for all projects that I have. Do you think this can be interesting to a wider audience?

The PR implementation might not be the best, but it illustrates the idea. I can install gem globally and execute RSpec with knapsack rspec.

What do you think about this? Thanks.