### PR TITLE
Don't exit on successful RSpec and Cucumber runs

### DIFF
--- a/lib/knapsack/runners/cucumber_runner.rb
+++ b/lib/knapsack/runners/cucumber_runner.rb
@@ -15,7 +15,7 @@ module Knapsack
         cmd = %Q[bundle exec cucumber #{args} -- #{allocator.stringify_node_tests}]
 
         system(cmd)
-        exit($?.exitstatus)
+        exit($?.exitstatus) unless $?.exitstatus == 0
       end
     end
   end

--- a/lib/knapsack/runners/rspec_runner.rb
+++ b/lib/knapsack/runners/rspec_runner.rb
@@ -15,7 +15,7 @@ module Knapsack
         cmd = %Q[bundle exec rspec #{args} --default-path #{allocator.test_dir} -- #{allocator.stringify_node_tests}]
 
         system(cmd)
-        exit($?.exitstatus)
+        exit($?.exitstatus) unless $?.exitstatus == 0
       end
     end
   end


### PR DESCRIPTION
In our CI setup, we run a single Rake task that invokes multiple test suites, including RSpec and Cucumber. We wish to use Knapsack to parallelise the RSpec and Cucumber suites; however, both `RSpecRunner` and `CucumberRunner` end with a call to `exit`, which exits Rake whether or not the suite ran successfully. This prevented any subsequent Rake tasks from running.

Knapsack’s runners should coexist with other Rake tasks, including any that may depend on the Knapsack tasks running first.

This change only `exit`s from Knapsack when the child process exited with a non-zero status.