### PR TITLE
Change file path patterns to support 1-level symlinks by default

### DIFF
--- a/lib/knapsack/adapters/base_adapter.rb
+++ b/lib/knapsack/adapters/base_adapter.rb
@@ -2,7 +2,7 @@ module Knapsack
   module Adapters
     class BaseAdapter
       # Just examples, please overwrite constants in subclasses
-      TEST_DIR_PATTERN = 'test/**/*_test.rb'
+      TEST_DIR_PATTERN = 'test/**{,/*/**}/*_test.rb'
       REPORT_PATH = 'knapsack_base_report.json'
 
       def self.bind

--- a/lib/knapsack/adapters/cucumber_adapter.rb
+++ b/lib/knapsack/adapters/cucumber_adapter.rb
@@ -1,7 +1,7 @@
 module Knapsack
   module Adapters
     class CucumberAdapter < BaseAdapter
-      TEST_DIR_PATTERN = 'features/**/*.feature'
+      TEST_DIR_PATTERN = 'features/**{,/*/**}/*.feature'
       REPORT_PATH = 'knapsack_cucumber_report.json'
 
       def bind_time_tracker

--- a/lib/knapsack/adapters/minitest_adapter.rb
+++ b/lib/knapsack/adapters/minitest_adapter.rb
@@ -1,7 +1,7 @@
 module Knapsack
   module Adapters
     class MinitestAdapter < BaseAdapter
-      TEST_DIR_PATTERN = 'test/**/*_test.rb'
+      TEST_DIR_PATTERN = 'test/**{,/*/**}/*_test.rb'
       REPORT_PATH = 'knapsack_minitest_report.json'
       @@parent_of_test_dir = nil
 

--- a/lib/knapsack/adapters/rspec_adapter.rb
+++ b/lib/knapsack/adapters/rspec_adapter.rb
@@ -1,7 +1,7 @@
 module Knapsack
   module Adapters
     class RspecAdapter < BaseAdapter
-      TEST_DIR_PATTERN = 'spec/**/*_spec.rb'
+      TEST_DIR_PATTERN = 'spec/**{,/*/**}/*_spec.rb'
       REPORT_PATH = 'knapsack_rspec_report.json'
 
       def bind_time_tracker


### PR DESCRIPTION
While trying to use knapsack to run RSpec that is symlink-ed to a different directory, me and my team spent a fair amount of time trying to figure out why Knapsack wouldn't load our knapsack reports correctly.

After digging into the knapsack code, we found out that by default, the file path pattern provided by default does not follow symlinks.

I would like to propose that we support follow at least 1-level symlinks by default