### PR TITLE
Rename RspecAdapter to RSpecAdapter so that it is consistent

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ require 'knapsack'
 
 # CUSTOM_CONFIG_GOES_HERE
 
-Knapsack::Adapters::RspecAdapter.bind
+Knapsack::Adapters::RSpecAdapter.bind
 ```
 
 ### Step for Cucumber

--- a/lib/knapsack/adapters/rspec_adapter.rb
+++ b/lib/knapsack/adapters/rspec_adapter.rb
@@ -1,6 +1,6 @@
 module Knapsack
   module Adapters
-    class RspecAdapter < BaseAdapter
+    class RSpecAdapter < BaseAdapter
       TEST_DIR_PATTERN = 'spec/**/*_spec.rb'
       REPORT_PATH = 'knapsack_rspec_report.json'
 
@@ -13,7 +13,7 @@ module Knapsack
               else
                 example.metadata
               end
-            Knapsack.tracker.test_path = RspecAdapter.test_path(current_example_group)
+            Knapsack.tracker.test_path = RSpecAdapter.test_path(current_example_group)
             Knapsack.tracker.start_timer
           end
 
@@ -53,6 +53,10 @@ module Knapsack
 
         example_group[:file_path]
       end
+    end
+
+    # This is added to provide backwards compatabiliy
+    class RspecAdapter < RSpecAdapter
     end
   end
 end

--- a/lib/knapsack/runners/rspec_runner.rb
+++ b/lib/knapsack/runners/rspec_runner.rb
@@ -2,7 +2,7 @@ module Knapsack
   module Runners
     class RSpecRunner
       def self.run(args)
-        allocator = Knapsack::AllocatorBuilder.new(Knapsack::Adapters::RspecAdapter).allocator
+        allocator = Knapsack::AllocatorBuilder.new(Knapsack::Adapters::RSpecAdapter).allocator
 
         puts
         puts 'Report specs:'

--- a/spec/knapsack/adapters/rspec_adapter_spec.rb
+++ b/spec/knapsack/adapters/rspec_adapter_spec.rb
@@ -1,4 +1,4 @@
-describe Knapsack::Adapters::RspecAdapter do
+describe Knapsack::Adapters::RSpecAdapter do
   context do
     before { expect(::RSpec).to receive(:configure) }
     it_behaves_like 'adapter'

--- a/spec/knapsack/allocator_builder_spec.rb
+++ b/spec/knapsack/allocator_builder_spec.rb
@@ -75,10 +75,16 @@ describe Knapsack::AllocatorBuilder do
       end
     end
 
+    context 'when RSpecAdapter' do
+      let(:adapter_class) { Knapsack::Adapters::RSpecAdapter }
+      it_behaves_like 'allocator builder'
+    end
+
+    # To make sure we do not break backwards compatibility
     context 'when RspecAdapter' do
       let(:adapter_class) { Knapsack::Adapters::RspecAdapter }
       it_behaves_like 'allocator builder'
-    end
+    end 
 
     context 'when CucumberAdapter' do
       let(:adapter_class) { Knapsack::Adapters::CucumberAdapter }
@@ -87,7 +93,7 @@ describe Knapsack::AllocatorBuilder do
   end
 
   describe '#test_dir' do
-    let(:adapter_class) { Knapsack::Adapters::RspecAdapter }
+    let(:adapter_class) { Knapsack::Adapters::RSpecAdapter }
 
     subject { allocator_builder.test_dir }
 

--- a/spec_examples/spec_helper.rb
+++ b/spec_examples/spec_helper.rb
@@ -15,7 +15,7 @@ if ENV['CUSTOM_LOGGER']
   Knapsack.logger.level = Logger::INFO
 end
 
-Knapsack::Adapters::RspecAdapter.bind
+Knapsack::Adapters::RSpecAdapter.bind
 
 RSpec.configure do |config|
   config.order = :random


### PR DESCRIPTION
While switching between Knapsack and Knapsack Pro, I noticed there were some naming inconsistencies.

Seeing that you use RSpec in Knapsack Pro and RSpec being the official name, I think this rename would be the right choice. 