### PR TITLE
Add ability to set test_dir using an environment variable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,6 +49,8 @@ script:
   - rm spec_examples/fast/1_spec.rb
   - KNAPSACK_TEST_FILE_PATTERN="spec_examples/**{,/*/**}/*_spec.rb" bundle exec rake knapsack:rspec
 
+  - bin/print_header.sh "Run specs from multiple directories with manually specified test_dir"
+  - KNAPSACK_TEST_DIR=spec_examples KNAPSACK_TEST_FILE_PATTERN="{spec_examples,spec_engine_examples}/**{,/*/**}/*_spec.rb" bundle exec rake knapsack:rspec
 
   - bin/print_header.sh "------------------------------------------------------"
 

--- a/README.md
+++ b/README.md
@@ -538,6 +538,12 @@ The leftover specs mean we don't have recorded time execution for those test fil
 The reason might be that someone added a new test file after knapsack report was generated. Another reason might be an empty spec file.
 If you have a lot of leftover specs then you can [generate knapsack report again](#how-to-generate-knapsack-report) to improve you test distribution across CI nodes.
 
+### How can I run tests from multiple directories?
+
+The test file pattern config option supports any glob pattern handled by [`Dir.glob`](http://ruby-doc.org/core-2.2.0/Dir.html#method-c-glob) and can be configured to pull test files from multiple directories. An example of this when using RSpec would be `"{spec,engines/**/spec}/**{,/*/**}/*_spec.rb"`. For complex cases like this, the test directory can't be extracted and must be specified manually using the `KNAPSACK_TEST_DIR` environment variable:
+
+    $ KNAPSACK_TEST_DIR=spec KNAPSACK_TEST_FILE_PATTERN="{spec,engines/**/spec}/**{,/*/**}/*_spec.rb" bundle exec rake knapsack:rspec
+
 ## Gem tests
 
 ### Spec

--- a/lib/knapsack/allocator.rb
+++ b/lib/knapsack/allocator.rb
@@ -22,7 +22,7 @@ module Knapsack
     end
 
     def test_dir
-      Knapsack::Config::Env.default_test_dir || @report_distributor.test_file_pattern.gsub(/^(.*?)\//).first
+      Knapsack::Config::Env.test_dir || @report_distributor.test_file_pattern.gsub(/^(.*?)\//).first
     end
   end
 end

--- a/lib/knapsack/allocator.rb
+++ b/lib/knapsack/allocator.rb
@@ -22,7 +22,7 @@ module Knapsack
     end
 
     def test_dir
-      @report_distributor.test_file_pattern.gsub(/^(.*?)\//).first
+      Knapsack::Config::Env.default_test_dir || @report_distributor.test_file_pattern.gsub(/^(.*?)\//).first
     end
   end
 end

--- a/lib/knapsack/allocator_builder.rb
+++ b/lib/knapsack/allocator_builder.rb
@@ -15,7 +15,7 @@ module Knapsack
     end
 
     def test_dir
-      test_file_pattern.split('/').first
+      Knapsack::Config::Env.default_test_dir || test_file_pattern.split('/').first
     end
 
     private

--- a/lib/knapsack/allocator_builder.rb
+++ b/lib/knapsack/allocator_builder.rb
@@ -15,7 +15,7 @@ module Knapsack
     end
 
     def test_dir
-      Knapsack::Config::Env.default_test_dir || test_file_pattern.split('/').first
+      Knapsack::Config::Env.test_dir || test_file_pattern.split('/').first
     end
 
     private

--- a/lib/knapsack/config/env.rb
+++ b/lib/knapsack/config/env.rb
@@ -18,8 +18,8 @@ module Knapsack
           ENV['KNAPSACK_TEST_FILE_PATTERN']
         end
 
-        def default_test_dir
-          ENV['KNAPSACK_DEFAULT_TEST_DIR']
+        def test_dir
+          ENV['KNAPSACK_TEST_DIR']
         end
 
         private

--- a/lib/knapsack/config/env.rb
+++ b/lib/knapsack/config/env.rb
@@ -18,6 +18,10 @@ module Knapsack
           ENV['KNAPSACK_TEST_FILE_PATTERN']
         end
 
+        def default_test_dir
+          ENV['KNAPSACK_DEFAULT_TEST_DIR']
+        end
+
         private
 
         def index_starting_from_one(index)

--- a/spec/knapsack/allocator_builder_spec.rb
+++ b/spec/knapsack/allocator_builder_spec.rb
@@ -97,18 +97,28 @@ describe Knapsack::AllocatorBuilder do
 
     subject { allocator_builder.test_dir }
 
-    before do
-      expect(Knapsack::Config::Env).to receive(:test_file_pattern).and_return(env_test_file_pattern)
-    end
-
-    context 'when ENV test_file_pattern has value' do
-      let(:env_test_file_pattern) { 'custom_spec/**{,/*/**}/*_spec.rb' }
+    context 'when ENV default_test_dir has value' do
+      before do
+        expect(Knapsack::Config::Env).to receive(:default_test_dir).and_return("custom_spec")
+      end
 
       it { should eq 'custom_spec' }
     end
 
-    context 'when ENV test_file_pattern has no value' do
-      it { should eq 'spec' }
+    context 'when ENV default_test_dir has no value' do
+      before do
+        expect(Knapsack::Config::Env).to receive(:test_file_pattern).and_return(env_test_file_pattern)
+      end
+
+      context 'when ENV test_file_pattern has value' do
+        let(:env_test_file_pattern) { 'custom_spec/**{,/*/**}/*_spec.rb' }
+
+        it { should eq 'custom_spec' }
+      end
+
+      context 'when ENV test_file_pattern has no value' do
+        it { should eq 'spec' }
+      end
     end
   end
 end

--- a/spec/knapsack/allocator_builder_spec.rb
+++ b/spec/knapsack/allocator_builder_spec.rb
@@ -97,15 +97,15 @@ describe Knapsack::AllocatorBuilder do
 
     subject { allocator_builder.test_dir }
 
-    context 'when ENV default_test_dir has value' do
+    context 'when ENV test_dir has value' do
       before do
-        expect(Knapsack::Config::Env).to receive(:default_test_dir).and_return("custom_spec")
+        expect(Knapsack::Config::Env).to receive(:test_dir).and_return("custom_spec")
       end
 
       it { should eq 'custom_spec' }
     end
 
-    context 'when ENV default_test_dir has no value' do
+    context 'when ENV test_dir has no value' do
       before do
         expect(Knapsack::Config::Env).to receive(:test_file_pattern).and_return(env_test_file_pattern)
       end

--- a/spec/knapsack/allocator_spec.rb
+++ b/spec/knapsack/allocator_spec.rb
@@ -43,14 +43,26 @@ describe Knapsack::Allocator do
   end
 
   describe '#test_dir' do
-    let(:test_file_pattern) { "test_dir/**{,/*/**}/*_spec.rb" }
-
     subject { allocator.test_dir }
 
-    before do
-      expect(report_distributor).to receive(:test_file_pattern).and_return(test_file_pattern)
+    context 'when ENV default_test_dir has value' do
+      let(:default_test_dir) { "custom_dir" }
+
+      before do
+        expect(Knapsack::Config::Env).to receive(:default_test_dir).and_return(default_test_dir)
+      end
+
+      it { should eql 'custom_dir' }
     end
 
-    it { should eql 'test_dir/' }
+    context 'when ENV default_test_dir has no value' do
+      let(:test_file_pattern) { "test_dir/**{,/*/**}/*_spec.rb" }
+
+      before do
+        expect(report_distributor).to receive(:test_file_pattern).and_return(test_file_pattern)
+      end
+
+      it { should eql 'test_dir/' }
+    end
   end
 end

--- a/spec/knapsack/allocator_spec.rb
+++ b/spec/knapsack/allocator_spec.rb
@@ -45,17 +45,17 @@ describe Knapsack::Allocator do
   describe '#test_dir' do
     subject { allocator.test_dir }
 
-    context 'when ENV default_test_dir has value' do
-      let(:default_test_dir) { "custom_dir" }
+    context 'when ENV test_dir has value' do
+      let(:test_dir) { "custom_dir" }
 
       before do
-        expect(Knapsack::Config::Env).to receive(:default_test_dir).and_return(default_test_dir)
+        expect(Knapsack::Config::Env).to receive(:test_dir).and_return(test_dir)
       end
 
       it { should eql 'custom_dir' }
     end
 
-    context 'when ENV default_test_dir has no value' do
+    context 'when ENV test_dir has no value' do
       let(:test_file_pattern) { "test_dir/**{,/*/**}/*_spec.rb" }
 
       before do

--- a/spec/knapsack/config/env_spec.rb
+++ b/spec/knapsack/config/env_spec.rb
@@ -96,4 +96,18 @@ describe Knapsack::Config::Env do
       it { should be_nil }
     end
   end
+
+  describe '.default_test_dir' do
+    subject { described_class.default_test_dir }
+
+    context 'when ENV exists' do
+      let(:default_test_dir) { 'spec' }
+      before { stub_const("ENV", { 'KNAPSACK_DEFAULT_TEST_DIR' => default_test_dir }) }
+      it { should eql default_test_dir }
+    end
+
+    context "when ENV doesn't exist" do
+      it { should be_nil }
+    end
+  end
 end

--- a/spec/knapsack/config/env_spec.rb
+++ b/spec/knapsack/config/env_spec.rb
@@ -97,13 +97,13 @@ describe Knapsack::Config::Env do
     end
   end
 
-  describe '.default_test_dir' do
-    subject { described_class.default_test_dir }
+  describe '.test_dir' do
+    subject { described_class.test_dir }
 
     context 'when ENV exists' do
-      let(:default_test_dir) { 'spec' }
-      before { stub_const("ENV", { 'KNAPSACK_DEFAULT_TEST_DIR' => default_test_dir }) }
-      it { should eql default_test_dir }
+      let(:test_dir) { 'spec' }
+      before { stub_const("ENV", { 'KNAPSACK_TEST_DIR' => test_dir }) }
+      it { should eql test_dir }
     end
 
     context "when ENV doesn't exist" do

--- a/spec_engine_examples/1_spec.rb
+++ b/spec_engine_examples/1_spec.rb
@@ -1,0 +1,3 @@
+describe 'Engine 1' do
+  it {}
+end


### PR DESCRIPTION
Prior to this commit, `test_dir` was extracted from the test file pattern using a regex. For example, using the default RSpec test file pattern of `spec/**{,/*/**}/*_spec.rb`, `test_dir` would be extracted in one of two ways:

```ruby
"spec/**{,/*/**}/*_spec.rb".split('/').first # => "spec"
"spec/**{,/*/**}/*_spec.rb".gsub(/^(.*?)\//).first # => "spec/"
```

The end result is effectively the same and works great for this case. However, when using a more complex test file pattern this method of extraction fails to provide the desired result. For example, say we had multiple spec directories under different trees:

```ruby
"{spec,engines/**/spec}/**{,/*/**}/*_spec.rb".split('/').first # => "{spec,engines"
"{spec,engines/**/spec}/**{,/*/**}/*_spec.rb".gsub(/^(.*?)\//).first # => "{spec,engines/"
```

In this case, the extracted `test_dir` is not usuable.

This commit modifies the code to use the value specified in `ENV["KNAPSACK_DEFAULT_TEST_DIR"]`, otherwise to extract the `test_dir` in the normal way.

_Note: We could attempt to make extraction more intelligent (and thereby more complex) but allowing one to specify it directly may be the simplest working solution for everyone._