### PR TITLE
Use Knapsack.logger for runner output

### DIFF
--- a/lib/knapsack/runners/cucumber_runner.rb
+++ b/lib/knapsack/runners/cucumber_runner.rb
@@ -4,13 +4,13 @@ module Knapsack
       def self.run(args)
         allocator = Knapsack::AllocatorBuilder.new(Knapsack::Adapters::CucumberAdapter).allocator
 
-        puts
-        puts 'Report features:'
-        puts allocator.report_node_tests
-        puts
-        puts 'Leftover features:'
-        puts allocator.leftover_node_tests
-        puts
+        Knapsack.logger.info
+        Knapsack.logger.info 'Report features:'
+        Knapsack.logger.info allocator.report_node_tests
+        Knapsack.logger.info
+        Knapsack.logger.info 'Leftover features:'
+        Knapsack.logger.info allocator.leftover_node_tests
+        Knapsack.logger.info
 
         cmd = %Q[bundle exec cucumber #{args} -- #{allocator.stringify_node_tests}]
 

--- a/lib/knapsack/runners/minitest_runner.rb
+++ b/lib/knapsack/runners/minitest_runner.rb
@@ -4,13 +4,13 @@ module Knapsack
       def self.run(args)
         allocator = Knapsack::AllocatorBuilder.new(Knapsack::Adapters::MinitestAdapter).allocator
 
-        puts
-        puts 'Report tests:'
-        puts allocator.report_node_tests
-        puts
-        puts 'Leftover tests:'
-        puts allocator.leftover_node_tests
-        puts
+        Knapsack.logger.info
+        Knapsack.logger.info 'Report tests:'
+        Knapsack.logger.info allocator.report_node_tests
+        Knapsack.logger.info
+        Knapsack.logger.info 'Leftover tests:'
+        Knapsack.logger.info allocator.leftover_node_tests
+        Knapsack.logger.info
 
         task_name = 'knapsack:minitest_run'
 

--- a/lib/knapsack/runners/rspec_runner.rb
+++ b/lib/knapsack/runners/rspec_runner.rb
@@ -4,13 +4,13 @@ module Knapsack
       def self.run(args)
         allocator = Knapsack::AllocatorBuilder.new(Knapsack::Adapters::RSpecAdapter).allocator
 
-        puts
-        puts 'Report specs:'
-        puts allocator.report_node_tests
-        puts
-        puts 'Leftover specs:'
-        puts allocator.leftover_node_tests
-        puts
+        Knapsack.logger.info
+        Knapsack.logger.info 'Report specs:'
+        Knapsack.logger.info allocator.report_node_tests
+        Knapsack.logger.info
+        Knapsack.logger.info 'Leftover specs:'
+        Knapsack.logger.info allocator.leftover_node_tests
+        Knapsack.logger.info
 
         cmd = %Q[bundle exec rspec #{args} --default-path #{allocator.test_dir} -- #{allocator.stringify_node_tests}]
 


### PR DESCRIPTION
Currently the different runners use `puts` to directly print their output to STDOUT. It would be really helpful to be able to suppress this output in certain contexts, or send it to a different location.

This commit changes them to use Knapsack.logger at INFO level. By default this will still print to STDOUT as before, but allows users to send the output elsewhere, or suppress it with a higher log level if desired.