### PR TITLE
Log the time offset warning at INFO if time not exceeded

### DIFF
--- a/lib/knapsack/adapters/cucumber_adapter.rb
+++ b/lib/knapsack/adapters/cucumber_adapter.rb
@@ -26,7 +26,10 @@ module Knapsack
 
       def bind_time_offset_warning
         ::Kernel.at_exit do
-          Knapsack.logger.warn(Presenter.time_offset_warning)
+          Knapsack.logger.log(
+            Presenter.time_offset_log_level,
+            Presenter.time_offset_warning
+          )
         end
       end
 

--- a/lib/knapsack/adapters/minitest_adapter.rb
+++ b/lib/knapsack/adapters/minitest_adapter.rb
@@ -37,7 +37,10 @@ module Knapsack
 
       def bind_time_offset_warning
         add_post_run_callback do
-          Knapsack.logger.warn(Presenter.time_offset_warning)
+          Knapsack.logger.log(
+            Presenter.time_offset_log_level,
+            Presenter.time_offset_warning
+          )
         end
       end
 

--- a/lib/knapsack/adapters/rspec_adapter.rb
+++ b/lib/knapsack/adapters/rspec_adapter.rb
@@ -39,7 +39,10 @@ module Knapsack
       def bind_time_offset_warning
         ::RSpec.configure do |config|
           config.after(:suite) do
-            Knapsack.logger.warn(Presenter.time_offset_warning)
+            Knapsack.logger.log(
+              Presenter.time_offset_log_level,
+              Presenter.time_offset_warning
+            )
           end
         end
       end

--- a/lib/knapsack/logger.rb
+++ b/lib/knapsack/logger.rb
@@ -6,6 +6,20 @@ module Knapsack
     INFO = 1
     WARN = 2
 
+    UnknownLogLevel = Class.new(StandardError)
+
+    def log(level, text=nil)
+      level_method =
+        case level
+        when DEBUG then :debug
+        when INFO then :info
+        when WARN then :warn
+        else raise UnknownLogLevel
+        end
+
+      public_send(level_method, text)
+    end
+
     def debug(text=nil)
       return if level != DEBUG
       puts text

--- a/lib/knapsack/presenter.rb
+++ b/lib/knapsack/presenter.rb
@@ -35,6 +35,14 @@ module Knapsack
         "Exceeded time: #{exceeded_time}"
       end
 
+      def time_offset_log_level
+        if Knapsack.tracker.time_exceeded?
+          Knapsack::Logger::WARN
+        else
+          Knapsack::Logger::INFO
+        end
+      end
+
       def time_offset_warning
         str = %{\n========= Knapsack Time Offset Warning ==========
 #{Presenter.time_offset}

--- a/spec/knapsack/adapters/cucumber_adapter_spec.rb
+++ b/spec/knapsack/adapters/cucumber_adapter_spec.rb
@@ -12,7 +12,7 @@ describe Knapsack::Adapters::CucumberAdapter do
     let(:logger) { instance_double(Knapsack::Logger) }
 
     before do
-      expect(Knapsack).to receive(:logger).and_return(logger)
+      allow(Knapsack).to receive(:logger).and_return(logger)
     end
 
     describe '#bind_time_tracker' do
@@ -83,11 +83,13 @@ describe Knapsack::Adapters::CucumberAdapter do
 
     describe '#bind_time_offset_warning' do
       let(:time_offset_warning) { 'Time offset warning' }
+      let(:log_level) { :info }
 
-      it do
+      it 'creates an at-exit callback to log the time offset message at the specified log level' do
         expect(::Kernel).to receive(:at_exit).and_yield
         expect(Knapsack::Presenter).to receive(:time_offset_warning).and_return(time_offset_warning)
-        expect(logger).to receive(:warn).with(time_offset_warning)
+        expect(Knapsack::Presenter).to receive(:time_offset_log_level).and_return(log_level)
+        expect(logger).to receive(:log).with(log_level, time_offset_warning)
 
         subject.bind_time_offset_warning
       end

--- a/spec/knapsack/adapters/minitest_adapter_spec.rb
+++ b/spec/knapsack/adapters/minitest_adapter_spec.rb
@@ -74,12 +74,14 @@ describe Knapsack::Adapters::MinitestAdapter do
 
     describe '#bind_time_offset_warning' do
       let(:time_offset_warning) { 'Time offset warning' }
+      let(:log_level) { :info }
 
-      it do
+      it 'creates a post-run callback to log the time offset message at the specified log level' do
         expect(::Minitest).to receive(:after_run).and_yield
 
         expect(Knapsack::Presenter).to receive(:time_offset_warning).and_return(time_offset_warning)
-        expect(logger).to receive(:warn).with(time_offset_warning)
+        expect(Knapsack::Presenter).to receive(:time_offset_log_level).and_return(log_level)
+        expect(logger).to receive(:log).with(log_level, time_offset_warning)
 
         subject.bind_time_offset_warning
       end

--- a/spec/knapsack/adapters/rspec_adapter_spec.rb
+++ b/spec/knapsack/adapters/rspec_adapter_spec.rb
@@ -65,13 +65,15 @@ describe Knapsack::Adapters::RSpecAdapter do
 
     describe '#bind_time_offset_warning' do
       let(:time_offset_warning) { 'Time offset warning' }
+      let(:log_level) { :info }
 
-      it do
+      it 'creates a post-suite callback to log the time offset message at the specified log level' do
         expect(config).to receive(:after).with(:suite).and_yield
         expect(::RSpec).to receive(:configure).and_yield(config)
 
         expect(Knapsack::Presenter).to receive(:time_offset_warning).and_return(time_offset_warning)
-        expect(logger).to receive(:warn).with(time_offset_warning)
+        expect(Knapsack::Presenter).to receive(:time_offset_log_level).and_return(log_level)
+        expect(logger).to receive(:log).with(log_level, time_offset_warning)
 
         subject.bind_time_offset_warning
       end

--- a/spec/knapsack/logger_spec.rb
+++ b/spec/knapsack/logger_spec.rb
@@ -57,4 +57,25 @@ describe Knapsack::Logger do
       it { expect { subject.warn(text) }.to output(/#{text}/).to_stdout }
     end
   end
+
+  describe '#log' do
+    let(:log_level) { Knapsack::Logger::INFO }
+    let(:log_message) { 'log-message' }
+
+    it 'delegates to the method matching the specified log level' do
+      expect(subject).to receive(:info).with(log_message)
+
+      subject.log(log_level, log_message)
+    end
+
+    context 'when the log level is unknown' do
+      let(:log_level) { 5 }
+
+      it 'raises an UnknownLogLevel error' do
+        expect {
+          subject.log(log_level, log_message)
+        }.to raise_error Knapsack::Logger::UnknownLogLevel
+      end
+    end
+  end
 end

--- a/spec/knapsack/presenter_spec.rb
+++ b/spec/knapsack/presenter_spec.rb
@@ -45,6 +45,29 @@ describe Knapsack::Presenter do
     it { should eql "Knapsack report was generated. Preview:\n{}" }
   end
 
+  describe '.time_offset_log_level' do
+    before do
+      allow(Knapsack).to receive(:tracker) { tracker }
+      allow(tracker).to receive(:time_exceeded?).and_return(time_exceeded)
+    end
+
+    context 'when the time offset is exceeded' do
+      let(:time_exceeded) { true }
+
+      it 'returns a WARN log level' do
+        expect(described_class.time_offset_log_level).to eq(Knapsack::Logger::WARN)
+      end
+    end
+
+    context 'when the time offset is not exceeded' do
+      let(:time_exceeded) { false }
+
+      it 'returns an INFO log level' do
+        expect(described_class.time_offset_log_level).to eq(Knapsack::Logger::INFO)
+      end
+    end
+  end
+
   describe '.time_offset_warning' do
     let(:time_offset_in_seconds) { 30 }
     let(:max_node_time_execution) { 60 }


### PR DESCRIPTION
Hi @ArturT - thanks for releasing the last logging PR, my colleagues are really happy with the cleaner test output. 👍 

There's one more source of regular output that we'd like to suppress if possible, which is the time offset warning. Currently, at the end of every suite run, the node's time offset warning is logged at WARN level. However, if the allowed time offset is not exceeded, this doesn't require user action, so we'd quite like to suppress it.

This change modifies the reporting calls to log the message at INFO level if the time offset is not exceeded, and WARN if it is exceeded. This allows a user to set their log level to WARN, and receive the message only when they need to rebalance their knapsack timing report.

I hope the approach is okay - I considered pushing the logger calls into the `Presenter` class itself (because there's a degree of duplication between the different adapters), but that didn't seem like a presentational responsibility, so I left it as-is. If you'd prefer another solution, though, just let me know.