### PR TITLE
Add support for Spinach

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -82,5 +82,29 @@ script:
   - bin/print_header.sh "Run tests when test file was removed and still exists in knapsack report json"
   - rm test_examples/fast/unit_test.rb
   - KNAPSACK_TEST_FILE_PATTERN="test_examples/**{,/*/**}/*_test.rb" bundle exec rake knapsack:minitest
+
+  
+  # Tests for example spinach test suite
+  - bin/print_header.sh "Generate knapsack report"
+  - KNAPSACK_GENERATE_REPORT=true bundle exec spinach -f spinach_examples
+
+  - bin/print_header.sh "Run tests with enabled time offset warning"
+  - bundle exec spinach -f spinach_examples
+
+  - bin/print_header.sh "Run rake task for the first CI node"
+  - CI_NODE_TOTAL=2 CI_NODE_INDEX=0 KNAPSACK_TEST_FILE_PATTERN="spinach_examples/**{,/*/**}/*.feature" bundle exec rake "knapsack:spinach[-f spinach_examples]"
+  - bin/print_header.sh "Run rake task for the second CI node"
+  - CI_NODE_TOTAL=2 CI_NODE_INDEX=1 KNAPSACK_TEST_FILE_PATTERN="spinach_examples/**{,/*/**}/*.feature" bundle exec rake "knapsack:spinach[-f spinach_examples]"
+
+  - bin/print_header.sh "Run tests with custom knapsack logger"
+  - CUSTOM_LOGGER=true KNAPSACK_TEST_FILE_PATTERN="spinach_examples/**{,/*/**}/*.feature" bundle exec rake "knapsack:spinach[-f spinach_examples]"
+
+  - bin/print_header.sh "Run tests for custom knapsack report path"
+  - cp knapsack_spinach_report.json knapsack_custom_spinach_report.json
+  - KNAPSACK_REPORT_PATH="knapsack_custom_spinach_report.json" KNAPSACK_TEST_FILE_PATTERN="spinach_examples/**{,/*/**}/*.feature" bundle exec rake "knapsack:spinach[-f spinach_examples]"
+
+  - bin/print_header.sh "Run tests when test file was removed and still exists in knapsack report json"
+  - rm spinach_examples/scenario1.feature
+  - KNAPSACK_TEST_FILE_PATTERN="spinach_examples/**{,/*/**}/*.feature" bundle exec rake "knapsack:spinach[-f spinach_examples]"
 notifications:
   email: false

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Presentations about gem:
   - [Step for RSpec](#step-for-rspec)
   - [Step for Cucumber](#step-for-cucumber)
   - [Step for Minitest](#step-for-minitest)
+  - [Step for Spinach](#step-for-spinach)
   - [Custom configuration](#custom-configuration)
   - [Common step](#common-step)
     - [Adding or removing tests](#adding-or-removing-tests)
@@ -51,6 +52,7 @@ Presentations about gem:
     - [Passing arguments to rspec](#passing-arguments-to-rspec)
     - [Passing arguments to cucumber](#passing-arguments-to-cucumber)
     - [Passing arguments to minitest](#passing-arguments-to-minitest)
+    - [Passing arguments to spinach](#passing-arguments-to-spinach)
   - [Knapsack binary](#knapsack-binary)
   - [Info for CircleCI users](#info-for-circleci-users)
     - [Step 1](#step-1)
@@ -150,9 +152,21 @@ knapsack_adapter = Knapsack::Adapters::MinitestAdapter.bind
 knapsack_adapter.set_test_helper_path(__FILE__)
 ```
 
+### Step for Spinach
+
+Create file `features/support/knapsack.rb` and add there:
+
+```ruby
+require 'knapsack'
+
+# CUSTOM_CONFIG_GOES_HERE
+
+Knapsack::Adapters::SpinachAdapter.bind
+```
+
 ### Custom configuration
 
-You can change default Knapsack configuration for RSpec, Cucumber or Minitest tests. Here are examples what you can do. Put below configuration instead of `CUSTOM_CONFIG_GOES_HERE`.
+You can change default Knapsack configuration for RSpec, Cucumber, Minitest or Spinach tests. Here are examples what you can do. Put below configuration instead of `CUSTOM_CONFIG_GOES_HERE`.
 
 ```ruby
 Knapsack.tracker.config({
@@ -184,7 +198,10 @@ Generate time execution report for your test files. Run below command on one of 
     # Step for Minitest
     $ KNAPSACK_GENERATE_REPORT=true bundle exec rake test
 
-Commit generated report `knapsack_rspec_report.json`, `knapsack_cucumber_report.json` or `knapsack_minitest_report.json` into your repository.
+    # Step for Spinach
+    $ KNAPSACK_GENERATE_REPORT=true bundle exec spinach
+
+Commit generated report `knapsack_rspec_report.json`, `knapsack_cucumber_report.json`, `knapsack_minitest_report.json` or `knapsack_spinach_report.json` into your repository.
 
 This report should be updated only after you add a lot of new slow tests or you change existing ones which causes a big time execution difference between CI nodes. Either way, you will get time offset warning at the end of the rspec/cucumber/minitest results which reminds you when it’s a good time to regenerate the knapsack report.
 
@@ -211,6 +228,9 @@ On your CI server run this command for the first CI node. Update `CI_NODE_INDEX`
     # Step for Minitest
     $ CI_NODE_TOTAL=2 CI_NODE_INDEX=0 bundle exec rake knapsack:minitest
 
+    # Step for Spinach
+    $ CI_NODE_TOTAL=2 CI_NODE_INDEX=0 bundle exec rake knapsack:spinach
+
 You can add `KNAPSACK_TEST_FILE_PATTERN` if your tests are not in default directory. For instance:
 
     # Step for RSpec
@@ -222,6 +242,9 @@ You can add `KNAPSACK_TEST_FILE_PATTERN` if your tests are not in default direct
     # Step for Minitest
     $ KNAPSACK_TEST_FILE_PATTERN="directory_with_tests/**{,/*/**}/*_spec.rb" CI_NODE_TOTAL=2 CI_NODE_INDEX=0 bundle exec rake knapsack:minitest
 
+    # Step for Spinach
+    $ KNAPSACK_TEST_FILE_PATTERN="directory_with_features/**/*.feature" CI_NODE_TOTAL=2 CI_NODE_INDEX=0 bundle exec rake knapsack:spinach
+
 You can set `KNAPSACK_REPORT_PATH` if your knapsack report was saved in non default location. Example:
 
     # Step for RSpec
@@ -232,6 +255,9 @@ You can set `KNAPSACK_REPORT_PATH` if your knapsack report was saved in non defa
 
     # Step for Minitest
     $ KNAPSACK_REPORT_PATH="knapsack_custom_report.json" CI_NODE_TOTAL=2 CI_NODE_INDEX=0 bundle exec rake knapsack:minitest
+
+    # Step for Spinach
+    $ KNAPSACK_REPORT_PATH="knapsack_custom_report.json" CI_NODE_TOTAL=2 CI_NODE_INDEX=0 bundle exec rake knapsack:spinach
 
 ### Info about ENV variables
 
@@ -269,6 +295,12 @@ For instance to run verbose tests:
 
     $ bundle exec rake "knapsack:minitest[--verbose]"
 
+#### Passing arguments to spinach
+
+Add arguments to knapsack spinach task like this:
+
+    $ bundle exec rake "knapsack:spinach[--name feature]"
+    
 ### Knapsack binary
 
 You can install knapsack globally and use binary. For instance:
@@ -300,9 +332,12 @@ test:
 
     # Step for Minitest
     - KNAPSACK_GENERATE_REPORT=true bundle exec rake test
+
+    # Step for Spinach
+    - KNAPSACK_GENERATE_REPORT=true bundle exec spinach
 ```
 
-After tests pass on your CircleCI machine your should copy knapsack json report which is rendered at the end of rspec/cucumber/minitest results. Save it into your repository as `knapsack_rspec_report.json`, `knapsack_cucumber_report.json` or `knapsack_minitest_report.json` file and commit.
+After tests pass on your CircleCI machine your should copy knapsack json report which is rendered at the end of rspec/cucumber/minitest results. Save it into your repository as `knapsack_rspec_report.json`, `knapsack_cucumber_report.json`, `knapsack_minitest_report.json` or `knapsack_spinach_report.json` file and commit.
 
 #### Step 2
 
@@ -321,6 +356,10 @@ test:
 
     # Step for Minitest
     - bundle exec rake knapsack:minitest:
+        parallel: true # Caution: there are 8 spaces indentation!
+
+    # Step for Spinach
+    - bundle exec rake knapsack:spinach:
         parallel: true # Caution: there are 8 spaces indentation!
 ```
 
@@ -342,9 +381,12 @@ script:
 
   # Step for Minitest
   - "KNAPSACK_GENERATE_REPORT=true bundle exec rake test"
+
+  # Step for Spinach
+  - "KNAPSACK_GENERATE_REPORT=true bundle exec spinach"
 ```
 
-After tests pass your should copy knapsack json report which is rendered at the end of rspec/cucumber/minitest results. Save it into your repository as `knapsack_rspec_report.json`, `knapsack_cucumber_report.json` or `knapsack_minitest_report.json` file and commit.
+After tests pass your should copy knapsack json report which is rendered at the end of rspec/cucumber/minitest results. Save it into your repository as `knapsack_rspec_report.json`, `knapsack_cucumber_report.json`, `knapsack_minitest_report.json` or `knapsack_spinach_report.json` file and commit.
 
 #### Step 2
 
@@ -360,6 +402,9 @@ script:
 
   # Step for Minitest
   - "bundle exec rake knapsack:minitest"
+
+  # Step for Spinach
+  - "bundle exec rake knapsack:spinach"
 
 env:
   - CI_NODE_TOTAL=2 CI_NODE_INDEX=0
@@ -378,6 +423,9 @@ script:
 
   # Step for Minitest
   - "bundle exec rake knapsack:minitest"
+
+  # Step for Spinach
+  - "bundle exec rake knapsack:spinach"
 
 env:
   global:
@@ -411,7 +459,10 @@ For the first time run all tests at once with enabled report generator. Set up y
     # Step for Minitest
     KNAPSACK_GENERATE_REPORT=true bundle exec rake test
 
-After tests pass your should copy knapsack json report which is rendered at the end of rspec/cucumber/test results. Save it into your repository as `knapsack_rspec_report.json`, `knapsack_cucumber_report.json` or `knapsack_minitest_report.json` file and commit.
+    # Step for Spinach
+    KNAPSACK_GENERATE_REPORT=true bundle exec spinach
+
+After tests pass your should copy knapsack json report which is rendered at the end of rspec/cucumber/test results. Save it into your repository as `knapsack_rspec_report.json`, `knapsack_cucumber_report.json`, `knapsack_minitest_report.json` or `knapsack_spinach_report.json` file and commit.
 
 #### Step 2
 
@@ -424,6 +475,8 @@ Knapsack supports semaphoreapp ENVs `SEMAPHORE_THREAD_COUNT` and `SEMAPHORE_CURR
     bundle exec rake knapsack:cucumber
     ## Step for Minitest
     bundle exec rake knapsack:minitest
+    ## Step for Spinach
+    bundle exec rake knapsack:spinach
 
     # Thread 2
     ## Step for RSpec
@@ -432,6 +485,8 @@ Knapsack supports semaphoreapp ENVs `SEMAPHORE_THREAD_COUNT` and `SEMAPHORE_CURR
     bundle exec rake knapsack:cucumber
     ## Step for Minitest
     bundle exec rake knapsack:minitest
+    ## Step for Spinach
+    bundle exec rake knapsack:spinach
 
 Tests will be split across threads.
 
@@ -450,7 +505,10 @@ For the first time run all tests at once with enabled report generator. Run the 
     # Step for Minitest
     KNAPSACK_GENERATE_REPORT=true bundle exec rake test
 
-After tests pass your should copy knapsack json report which is rendered at the end of rspec/cucumber/minitest results. Save it into your repository as `knapsack_rspec_report.json`, `knapsack_cucumber_report.json` or `knapsack_minitest_report.json` file and commit.
+    # Step for Spinach
+    KNAPSACK_GENERATE_REPORT=true bundle exec spinach
+
+After tests pass your should copy knapsack json report which is rendered at the end of rspec/cucumber/minitest results. Save it into your repository as `knapsack_rspec_report.json`, `knapsack_cucumber_report.json`, `knapsack_minitest_report.json` or `knapsack_spinach_report.json` file and commit.
 
 #### Step 2
 
@@ -464,6 +522,9 @@ Knapsack supports buildkite ENVs `BUILDKITE_PARALLEL_JOB_COUNT` and `BUILDKITE_P
 
     # Step for Minitest
     bundle exec rake knapsack:minitest
+
+    # Step for Spinach
+    bundle exec rake knapsack:spinach
 
 ### Info for snap-ci.com users
 
@@ -480,7 +541,10 @@ For the first time run all tests at once with enabled report generator. Run the 
     # Step for Minitest
     KNAPSACK_GENERATE_REPORT=true bundle exec rake test
 
-After tests pass your should copy knapsack json report which is rendered at the end of rspec/cucumber/minitest results. Save it into your repository as `knapsack_rspec_report.json`, `knapsack_cucumber_report.json` or `knapsack_minitest_report.json` file and commit.
+    # Step for Spinach
+    KNAPSACK_GENERATE_REPORT=true bundle exec spinach
+
+After tests pass your should copy knapsack json report which is rendered at the end of rspec/cucumber/minitest results. Save it into your repository as `knapsack_rspec_report.json`, `knapsack_cucumber_report.json`, `knapsack_minitest_report.json` or `knapsack_spinach_report.json` file and commit.
 
 #### Step 2
 
@@ -494,6 +558,9 @@ Knapsack supports snap-ci.com ENVs `SNAP_WORKER_TOTAL` and `SNAP_WORKER_INDEX`. 
 
     # Step for Minitest
     bundle exec rake knapsack:minitest
+
+    # Step for Spinach
+    bundle exec rake knapsack:spinach
 
 ## FAQ
 

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ knapsack_adapter.set_test_helper_path(__FILE__)
 
 ### Step for Spinach
 
-Create file `features/support/knapsack.rb` and add there:
+Create file `features/support/env.rb` and add there:
 
 ```ruby
 require 'knapsack'

--- a/bin/knapsack
+++ b/bin/knapsack
@@ -9,6 +9,7 @@ MAP = {
   'rspec' => Knapsack::Runners::RSpecRunner,
   'cucumber' => Knapsack::Runners::CucumberRunner,
   'minitest' => Knapsack::Runners::MinitestRunner,
+  'spinach' => Knapsack::Runners::SpinachRunner,
 }
 
 runner_class = MAP[runner]

--- a/knapsack.gemspec
+++ b/knapsack.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec', '~> 3.0', '>= 2.0.0'
   spec.add_development_dependency 'rspec-its', '~> 1.2'
   spec.add_development_dependency 'cucumber', '>= 0'
+  spec.add_development_dependency 'spinach', '>= 0.8'
   spec.add_development_dependency 'minitest', '>= 5.0.0'
   spec.add_development_dependency 'codeclimate-test-reporter', '~> 0'
   spec.add_development_dependency 'pry', '~> 0'

--- a/lib/knapsack.rb
+++ b/lib/knapsack.rb
@@ -18,9 +18,11 @@ require_relative 'knapsack/adapters/base_adapter'
 require_relative 'knapsack/adapters/rspec_adapter'
 require_relative 'knapsack/adapters/cucumber_adapter'
 require_relative 'knapsack/adapters/minitest_adapter'
+require_relative 'knapsack/adapters/spinach_adapter'
 require_relative 'knapsack/runners/rspec_runner'
 require_relative 'knapsack/runners/cucumber_runner'
 require_relative 'knapsack/runners/minitest_runner'
+require_relative 'knapsack/runners/spinach_runner'
 
 module Knapsack
   class << self

--- a/lib/knapsack/adapters/spinach_adapter.rb
+++ b/lib/knapsack/adapters/spinach_adapter.rb
@@ -1,3 +1,5 @@
+require 'spinach'
+
 module Knapsack
   module Adapters
     class SpinachAdapter < BaseAdapter
@@ -6,7 +8,7 @@ module Knapsack
 
       def bind_time_tracker
         Spinach.hooks.before_scenario do |scenario_data, step_definitions|
-          Knapsack.tracker.test_path = scenario_data.feature.filename
+          Knapsack.tracker.test_path = SpinachAdapter.test_path(scenario_data)
           Knapsack.tracker.start_timer
         end
 
@@ -32,14 +34,8 @@ module Knapsack
         end
       end
 
-      def self.test_path(example_group)
-        unless example_group[:turnip]
-          until example_group[:parent_example_group].nil?
-            example_group = example_group[:parent_example_group]
-          end
-        end
-
-        example_group[:file_path]
+      def self.test_path(scenario)
+        scenario.feature.filename
       end
     end
   end

--- a/lib/knapsack/adapters/spinach_adapter.rb
+++ b/lib/knapsack/adapters/spinach_adapter.rb
@@ -1,0 +1,46 @@
+module Knapsack
+  module Adapters
+    class SpinachAdapter < BaseAdapter
+      TEST_DIR_PATTERN = 'features/**{,/*/**}/*.feature'
+      REPORT_PATH = 'knapsack_spinach_report.json'
+
+      def bind_time_tracker
+        Spinach.hooks.before_scenario do |scenario_data, step_definitions|
+          Knapsack.tracker.test_path = scenario_data.feature.filename
+          Knapsack.tracker.start_timer
+        end
+
+        Spinach.hooks.after_scenario do
+          Knapsack.tracker.stop_timer
+        end
+
+        Spinach.hooks.after_run do
+          Knapsack.logger.info(Presenter.global_time)
+        end
+      end
+
+      def bind_report_generator
+        Spinach.hooks.after_run do
+          Knapsack.report.save
+          Knapsack.logger.info(Presenter.report_details)
+        end
+      end
+
+      def bind_time_offset_warning
+        Spinach.hooks.after_run do
+          Knapsack.logger.warn(Presenter.time_offset_warning)
+        end
+      end
+
+      def self.test_path(example_group)
+        unless example_group[:turnip]
+          until example_group[:parent_example_group].nil?
+            example_group = example_group[:parent_example_group]
+          end
+        end
+
+        example_group[:file_path]
+      end
+    end
+  end
+end

--- a/lib/knapsack/runners/spinach_runner.rb
+++ b/lib/knapsack/runners/spinach_runner.rb
@@ -1,0 +1,22 @@
+module Knapsack
+  module Runners
+    class SpinachRunner
+      def self.run(args)
+        allocator = Knapsack::AllocatorBuilder.new(Knapsack::Adapters::SpinachAdapter).allocator
+
+        Knapsack.logger.info
+        Knapsack.logger.info 'Report features:'
+        Knapsack.logger.info allocator.report_node_tests
+        Knapsack.logger.info
+        Knapsack.logger.info 'Leftover features:'
+        Knapsack.logger.info allocator.leftover_node_tests
+        Knapsack.logger.info
+
+        cmd = %Q[bundle exec spinach #{args} -- #{allocator.stringify_node_tests}]
+
+        system(cmd)
+        exit($?.exitstatus) unless $?.exitstatus.zero?
+      end
+    end
+  end
+end

--- a/lib/tasks/knapsack_spinach.rake
+++ b/lib/tasks/knapsack_spinach.rake
@@ -1,0 +1,7 @@
+require 'knapsack'
+
+namespace :knapsack do
+  task :spinach, [:spinach_args] do |_, args|
+    Knapsack::Runners::SpinachRunner.run(args[:spinach_args])
+  end
+end

--- a/spec/knapsack/adapters/spinach_adapter_spec.rb
+++ b/spec/knapsack/adapters/spinach_adapter_spec.rb
@@ -1,0 +1,82 @@
+describe Knapsack::Adapters::SpinachAdapter do
+  context do
+    it_behaves_like 'adapter'
+  end
+
+  describe 'bind methods' do
+    let(:config) { double }
+    let(:logger) { instance_double(Knapsack::Logger) }
+
+    before do
+      expect(Knapsack).to receive(:logger).and_return(logger)
+    end
+
+    describe '#bind_time_tracker' do
+      let(:tracker) { instance_double(Knapsack::Tracker) }
+      let(:test_path) { 'spec/a_spec.rb' }
+      let(:global_time) { 'Global time: 01m 05s' }
+      let(:example_group) { double }
+      let(:scenario_data) do
+        double(feature: double(filename: 'a_spec.rb'))
+      end
+
+      it do
+        allow(Knapsack).to receive(:tracker).and_return(tracker)
+
+        expect(Spinach.hooks).to receive(:before_scenario).and_yield(scenario_data, nil)
+        expect(described_class).to receive(:test_path).with(scenario_data).and_return(test_path)
+        expect(tracker).to receive(:test_path=).with(test_path)
+        expect(tracker).to receive(:start_timer)
+
+        expect(Spinach.hooks).to receive(:after_scenario).and_yield
+        expect(tracker).to receive(:stop_timer)
+
+        expect(Spinach.hooks).to receive(:after_run).and_yield
+        expect(Knapsack::Presenter).to receive(:global_time).and_return(global_time)
+        expect(logger).to receive(:info).with(global_time)
+
+        subject.bind_time_tracker
+      end
+    end
+
+    describe '#bind_report_generator' do
+      let(:report) { instance_double(Knapsack::Report) }
+      let(:report_details) { 'Report details' }
+
+      it do
+        expect(Spinach.hooks).to receive(:after_run).and_yield
+
+        expect(Knapsack).to receive(:report).and_return(report)
+        expect(report).to receive(:save)
+
+        expect(Knapsack::Presenter).to receive(:report_details).and_return(report_details)
+        expect(logger).to receive(:info).with(report_details)
+
+        subject.bind_report_generator
+      end
+    end
+
+    describe '#bind_time_offset_warning' do
+      let(:time_offset_warning) { 'Time offset warning' }
+
+      it do
+        expect(Spinach.hooks).to receive(:after_run).and_yield
+
+        expect(Knapsack::Presenter).to receive(:time_offset_warning).and_return(time_offset_warning)
+        expect(logger).to receive(:warn).with(time_offset_warning)
+
+        subject.bind_time_offset_warning
+      end
+    end
+  end
+
+  describe '.test_path' do
+    let(:scenario_data) do
+      double(feature: double(filename: 'a_spec.rb'))
+    end
+
+    subject { described_class.test_path(scenario_data) }
+
+    it { should eql 'a_spec.rb' }
+  end
+end

--- a/spinach_examples/scenario1.feature
+++ b/spinach_examples/scenario1.feature
@@ -1,0 +1,6 @@
+Feature: Test how spinach works for first test
+  Scenario: Format greeting
+    Given I have an empty array
+    And I append my first name and my last name to it
+    When I pass it to my super-duper method
+    Then the output should contain a formal greeting

--- a/spinach_examples/scenario2.feature
+++ b/spinach_examples/scenario2.feature
@@ -1,0 +1,6 @@
+Feature: Test how spinach works for second test
+  Scenario: Informal greeting
+    Given I have an empty array
+    And I append only my first name to it
+    When I pass it to my super-duper method
+    Then the output should contain a casual greeting

--- a/spinach_examples/steps/test_how_spinach_works_for_first_test.rb
+++ b/spinach_examples/steps/test_how_spinach_works_for_first_test.rb
@@ -1,0 +1,13 @@
+class Spinach::Features::TestHowSpinachWorksForFirstTest < Spinach::FeatureSteps
+  step 'I have an empty array' do
+  end
+
+  step 'I append my first name and my last name to it' do
+  end
+
+  step 'I pass it to my super-duper method' do
+  end
+
+  step 'the output should contain a formal greeting' do
+  end
+end

--- a/spinach_examples/steps/test_how_spinach_works_for_second_test.rb
+++ b/spinach_examples/steps/test_how_spinach_works_for_second_test.rb
@@ -1,0 +1,13 @@
+class Spinach::Features::TestHowSpinachWorksForSecondTest < Spinach::FeatureSteps
+  step 'I have an empty array' do
+  end
+
+  step 'I append only my first name to it' do
+  end
+
+  step 'I pass it to my super-duper method' do
+  end
+
+  step 'the output should contain a casual greeting' do
+  end
+end

--- a/spinach_examples/support/env.rb
+++ b/spinach_examples/support/env.rb
@@ -1,0 +1,4 @@
+require 'rspec'
+require 'knapsack'
+
+Knapsack::Adapters::SpinachAdapter.bind


### PR DESCRIPTION
This adds support for Spinach: https://github.com/codegram/spinach

This MR covers:
- a new SpinachAdapter,
- a rspec tests for SpinachAdapter,
- a `spinach_examples` to run test on Travis-CI,
- updates README.md with description how to use it.

