### PR TITLE
Add KNAPSACK_LOG_LEVEL option

### DIFF
--- a/README.md
+++ b/README.md
@@ -658,6 +658,14 @@ For instance to run subset of tests for the first CI node with specified seed yo
 
 Above example is for RSpec. You can use respectively rake task name and token environment variable when you want to run tests for minitest, cucumber or spinach.
 
+### How can I change log level?
+
+You can change log level by specifying the `KNAPSACK_LOG_LEVEL` environment variable.
+
+    KNAPSACK_LOG_LEVEL=warn bundle exec rake knapsack:rspec
+    
+Available values are `debug`, `info`, and `warn`. The default log level is `info`.
+
 ## Gem tests
 
 ### Spec

--- a/lib/knapsack.rb
+++ b/lib/knapsack.rb
@@ -48,7 +48,7 @@ module Knapsack
     def logger
       return @@logger if @@logger
       log = Knapsack::Logger.new
-      log.level = Knapsack::Logger::INFO
+      log.level = Knapsack::Config::Env.log_level
       @@logger = log
     end
 

--- a/lib/knapsack/config/env.rb
+++ b/lib/knapsack/config/env.rb
@@ -22,6 +22,14 @@ module Knapsack
           ENV['KNAPSACK_TEST_DIR']
         end
 
+        def log_level
+          {
+            "debug" => Knapsack::Logger::DEBUG,
+            "info"  => Knapsack::Logger::INFO,
+            "warn"  => Knapsack::Logger::WARN,
+          }[ENV['KNAPSACK_LOG_LEVEL']] || Knapsack::Logger::INFO
+        end
+
         private
 
         def index_starting_from_one(index)

--- a/spec/knapsack/config/env_spec.rb
+++ b/spec/knapsack/config/env_spec.rb
@@ -110,4 +110,18 @@ describe Knapsack::Config::Env do
       it { should be_nil }
     end
   end
+
+  describe '.log_level' do
+    subject { described_class.log_level }
+
+    context 'when ENV exists' do
+      let(:log_level) { 'debug' }
+      before { stub_const("ENV", { 'KNAPSACK_LOG_LEVEL' => log_level }) }
+      it { should eql Knapsack::Logger::DEBUG }
+    end
+
+    context "when ENV doesn't exist" do
+      it { should eql Knapsack::Logger::INFO }
+    end
+  end
 end


### PR DESCRIPTION
Fixes #43

Added `KNAPSACK_LOG_LEVEL` that specifies the log level. It defaults to `INFO` if not specified.