### PR TITLE
Get rid of call #zero? method on $?.exitstatus

### DIFF
--- a/lib/knapsack/runners/cucumber_runner.rb
+++ b/lib/knapsack/runners/cucumber_runner.rb
@@ -15,7 +15,7 @@ module Knapsack
         cmd = %Q[bundle exec cucumber #{args} --require #{allocator.test_dir} -- #{allocator.stringify_node_tests}]
 
         system(cmd)
-        exit($?.exitstatus) unless $?.exitstatus.zero?
+        exit($?.exitstatus) unless $?.exitstatus == 0
       end
     end
   end

--- a/lib/knapsack/runners/rspec_runner.rb
+++ b/lib/knapsack/runners/rspec_runner.rb
@@ -15,7 +15,7 @@ module Knapsack
         cmd = %Q[bundle exec rspec #{args} --default-path #{allocator.test_dir} -- #{allocator.stringify_node_tests}]
 
         system(cmd)
-        exit($?.exitstatus) unless $?.exitstatus.zero?
+        exit($?.exitstatus) unless $?.exitstatus == 0
       end
     end
   end

--- a/lib/knapsack/runners/spinach_runner.rb
+++ b/lib/knapsack/runners/spinach_runner.rb
@@ -15,7 +15,7 @@ module Knapsack
         cmd = %Q[bundle exec spinach #{args} --features_path #{allocator.test_dir} -- #{allocator.stringify_node_tests}]
 
         system(cmd)
-        exit($?.exitstatus) unless $?.exitstatus.zero?
+        exit($?.exitstatus) unless $?.exitstatus == 0
       end
     end
   end


### PR DESCRIPTION
`$?.exitstatus` returns the least significant eight bits of the return code of stat and the method returns **fixnum** or **nil**.
If `$?.exitstatus` returns **nil**, `$?.exitstatus.zero?`crashes with a `NoMethodError`:

```ruby
NoMethodError: undefined method `zero?' for nil:NilClass
```