### PR TITLE
Moves Timecop to development dependency, Issue #55 

### DIFF
--- a/knapsack.gemspec
+++ b/knapsack.gemspec
@@ -19,7 +19,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency 'rake', '>= 0'
-  spec.add_dependency 'timecop', '>= 0.1.0'
 
   spec.add_development_dependency 'bundler', '~> 1.6'
   spec.add_development_dependency 'rspec', '~> 3.0', '>= 2.0.0'
@@ -29,4 +28,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'minitest', '>= 5.0.0'
   spec.add_development_dependency 'codeclimate-test-reporter', '~> 0'
   spec.add_development_dependency 'pry', '~> 0'
+  spec.add_development_dependency 'timecop', '>= 0.1.0'
 end

--- a/lib/extensions/time.rb
+++ b/lib/extensions/time.rb
@@ -1,0 +1,7 @@
+class Time
+  class << self
+    # The alias method .now_without_mock is different than in Timecop gem (timecop uses .now_without_mock_time)
+    # to ensure there will be no conflict
+    alias_method :raw_now, :now
+  end
+end

--- a/lib/knapsack.rb
+++ b/lib/knapsack.rb
@@ -1,6 +1,6 @@
 require 'singleton'
 require 'rake/testtask'
-require 'timecop'
+require_relative 'extensions/time'
 require_relative 'knapsack/version'
 require_relative 'knapsack/config/env'
 require_relative 'knapsack/config/tracker'

--- a/lib/knapsack/tracker.rb
+++ b/lib/knapsack/tracker.rb
@@ -81,7 +81,11 @@ module Knapsack
     end
 
     def now_without_mock_time
-      Time.now_without_mock_time
+      if defined?(Timecop)
+        Time.now_without_mock_time
+      else
+        Time.raw_now
+      end
     end
   end
 end

--- a/spec/knapsack/extensions/time_spec.rb
+++ b/spec/knapsack/extensions/time_spec.rb
@@ -1,0 +1,5 @@
+describe Time do
+  it "will respond to :raw_now" do
+    expect(Time.respond_to?(:raw_now)).to be true
+  end
+end


### PR DESCRIPTION
Resolves [#55](https://github.com/ArturT/knapsack/issues/55) 

Moves Timecop to development dependency
Use Timecop now_without_mock_time method when Timecop available. In
other case use the Time.raw_now method