### PR TITLE
Update RSpec timing adaptor to be more resilient

### DIFF
--- a/lib/knapsack/adapters/rspec_adapter.rb
+++ b/lib/knapsack/adapters/rspec_adapter.rb
@@ -6,7 +6,7 @@ module Knapsack
 
       def bind_time_tracker
         ::RSpec.configure do |config|
-          config.before(:each) do
+          config.prepend_before(:each) do
             current_example_group =
               if ::RSpec.respond_to?(:current_example)
                 ::RSpec.current_example.metadata[:example_group]
@@ -17,7 +17,7 @@ module Knapsack
             Knapsack.tracker.start_timer
           end
 
-          config.after(:each) do
+          config.append_after(:each) do
             Knapsack.tracker.stop_timer
           end
 

--- a/spec/knapsack/adapters/rspec_adapter_spec.rb
+++ b/spec/knapsack/adapters/rspec_adapter_spec.rb
@@ -24,8 +24,8 @@ describe Knapsack::Adapters::RSpecAdapter do
       end
 
       it do
-        expect(config).to receive(:before).with(:each).and_yield
-        expect(config).to receive(:after).with(:each).and_yield
+        expect(config).to receive(:prepend_before).with(:each).and_yield
+        expect(config).to receive(:append_after).with(:each).and_yield
         expect(config).to receive(:after).with(:suite).and_yield
         expect(::RSpec).to receive(:configure).and_yield(config)
 


### PR DESCRIPTION
#### Overview
In a project where we are using Knapsack, we noticed that some tests were incorrectly reporting a much shorter time than they were actually taking.

After some investigation, I noticed that it was because we had `Knapsack::Adapters::RSpecAdapter.bind` placed at the bottom of our `spec_helper.rb`

Above this, we had an`RSpec.configure` block that contained a slow `after(:each)` block that was adding about 1 second per test - doing DB work.

Because `before` aliases `append_before` and `after` aliases `prepend_after`, if the bind happens after the config of these blocks, the `after` block that contains the end of the timing calculation is executed before the other config block.

http://www.rubydoc.info/github/rspec/rspec-core/RSpec%2FCore%2FConfiguration:after

#### Example Repo
I have pushed a minimal app that shows the issue here
https://github.com/aterris/knapsack-issue

#### Safer Implementation
While we did not match the prescribed documentation (by putting bind at the bottom instead of top of spec_helper), it feels like this is an easy mistake for other users to make and is also something we can help protect against.

RSpec provides `prepend_before` and `append_after` for extension type work that would fix this in most cases (including the sample app above). It is still possible to hit this if the user is using those methods directly, but this change would make that much less likely since users are not often using them. These methods were added in 2.10 as seen in the [changelog](https://relishapp.com/rspec/rspec-core/v/2-11/docs/changelog)

I have updated the `rspec_adaptor_spec.rb` but have not added a test specifically around this case. I can look into that but hadn't found what felt like a good way to test this yet.

#### Final Note
I actually noticed this bug originally with Knapsack Pro but ended up just making this PR here for now. If you are happy with this change, I can make at PR on pro as well, or you can do it yourself, whichever you prefer.