### PR TITLE
Add rails 5.1 systemtest instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -403,7 +403,7 @@ test:
   command: |
     # export word is important here!
     export KNAPSACK_GENERATE_REPORT=true
-    bundle exec rake test 
+    bundle exec rake test
 
 - run:
   name: Step for Spinach

--- a/README.md
+++ b/README.md
@@ -233,8 +233,12 @@ Generate time execution report for your test files. Run below command on one of 
 
     # Step for Minitest
     $ KNAPSACK_GENERATE_REPORT=true bundle exec rake test
+
     # If you use rails 5 then run this instead:
     $ KNAPSACK_GENERATE_REPORT=true bundle exec rake knapsack:minitest
+
+    # If you use rails 5.1's SystemTest, run both regular and system tests
+    $ KNAPSACK_GENERATE_REPORT=true bundle exec rake test test:system
 
     # Step for Spinach
     $ KNAPSACK_GENERATE_REPORT=true bundle exec spinach
@@ -372,6 +376,7 @@ test:
 
     # Step for Minitest
     - KNAPSACK_GENERATE_REPORT=true bundle exec rake test
+    - KNAPSACK_GENERATE_REPORT=true bundle exec rake test # For rails 5.1 with system tests
 
     # Step for Spinach
     - KNAPSACK_GENERATE_REPORT=true bundle exec spinach
@@ -398,7 +403,7 @@ test:
   command: |
     # export word is important here!
     export KNAPSACK_GENERATE_REPORT=true
-    bundle exec rake test
+    bundle exec rake test 
 
 - run:
   name: Step for Spinach
@@ -472,6 +477,7 @@ script:
 
   # Step for Minitest
   - "KNAPSACK_GENERATE_REPORT=true bundle exec rake test"
+  - "KNAPSACK_GENERATE_REPORT=true bundle exec rake test:system" # For rails 5.1 with system tests
 
   # Step for Spinach
   - "KNAPSACK_GENERATE_REPORT=true bundle exec spinach"
@@ -595,6 +601,7 @@ For the first time run all tests at once with enabled report generator. Run the 
 
     # Step for Minitest
     KNAPSACK_GENERATE_REPORT=true bundle exec rake test
+    KNAPSACK_GENERATE_REPORT=true bundle exec rake test test:system # rails 5.1 with system tests
 
     # Step for Spinach
     KNAPSACK_GENERATE_REPORT=true bundle exec spinach
@@ -631,6 +638,7 @@ For the first time run all tests at once with enabled report generator. Run the 
 
     # Step for Minitest
     KNAPSACK_GENERATE_REPORT=true bundle exec rake test
+    KNAPSACK_GENERATE_REPORT=true bundle exec rake test test:system # rails 5.1 with system tests
 
     # Step for Spinach
     KNAPSACK_GENERATE_REPORT=true bundle exec spinach


### PR DESCRIPTION
Sorry for the delay on this @ArturT ! Holidays got the better of me this year.

This PR bumps the readme doc by adding instructions for getting it to work with rails 5.1's systemtest. I haven't tested this on the multitude of CI providers there are instructions for, but the rails test commands to generate the report should work the same everywhere I'd think.

Let me know what changes etc you'd like me to make, happy to make tweaks to push this over the finish line. Thanks again for knapsack, it's saved me and my team tons of time.

Fixes https://github.com/ArturT/knapsack/issues/71 .