### PR TITLE
[CI] Test and adapt against Ruby 1.9.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -71,7 +71,8 @@ script:
 
   - bin/print_header.sh "Check passing arguments to minitest. Run verbose tests"
   - KNAPSACK_TEST_FILE_PATTERN="test_examples/**{,/*/**}/*_test.rb" bundle exec rake "knapsack:minitest[--verbose]"
-  - KNAPSACK_TEST_FILE_PATTERN="test_examples/**{,/*/**}/*_test.rb" bin/knapsack minitest "--verbose --pride"
+  - if [ "$TRAVIS_RUBY_VERSION" == "1.9.3" ]; then KNAPSACK_TEST_FILE_PATTERN="test_examples/**{,/*/**}/*_test.rb" bin/knapsack minitest "--verbose"; fi
+  - if [ "$TRAVIS_RUBY_VERSION" != "1.9.3" ]; then KNAPSACK_TEST_FILE_PATTERN="test_examples/**{,/*/**}/*_test.rb" bin/knapsack minitest "--verbose --pride"; fi
 
   - bin/print_header.sh "Run tests with custom knapsack logger"
   - CUSTOM_LOGGER=true KNAPSACK_TEST_FILE_PATTERN="test_examples/**{,/*/**}/*_test.rb" bundle exec rake knapsack:minitest

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@
 sudo: false
 language: ruby
 rvm:
+  - 1.9.3
   - 2.0.0
   - 2.2.2
   - 2.2.3

--- a/knapsack.gemspec
+++ b/knapsack.gemspec
@@ -18,6 +18,8 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
+  spec.required_ruby_version = '>= 1.9.3'
+
   spec.add_dependency 'rake', '>= 0'
 
   spec.add_development_dependency 'bundler', '~> 1.6'

--- a/test_examples/fast/shared_examples_test.rb
+++ b/test_examples/fast/shared_examples_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 
 class Minitest::SharedExamples < Module
-  include Minitest::Spec::DSL
+  include Minitest::Spec::DSL if RUBY_VERSION != "1.9.3"
 end
 
 SharedExampleSpec = Minitest::SharedExamples.new do

--- a/test_examples/test_helper.rb
+++ b/test_examples/test_helper.rb
@@ -3,8 +3,12 @@ require 'minitest/autorun'
 require 'knapsack'
 
 if RUBY_VERSION == "1.9.3"
-  Minitest = MiniTest
-  Minitest::Test = MiniTest::Unit::TestCase
+  unless defined? Minitest
+    Minitest = MiniTest
+  end
+  unless defined? Minitest::Test
+    Minitest::Test = MiniTest::Unit::TestCase
+  end
 end
 
 Knapsack.tracker.config({

--- a/test_examples/test_helper.rb
+++ b/test_examples/test_helper.rb
@@ -2,6 +2,11 @@ require 'minitest/autorun'
 
 require 'knapsack'
 
+if RUBY_VERSION == "1.9.3"
+  Minitest = MiniTest
+  Minitest::Test = MiniTest::Unit::TestCase
+end
+
 Knapsack.tracker.config({
   enable_time_offset_warning: true,
   time_offset_in_seconds: 3


### PR DESCRIPTION
Ruby built-in MiniTest is not exactly the same in 1.9.3 so we need to do some adaptation.

- Minitest in Ruby 1.9.3 https://ruby-doc.org/stdlib-1.9.3/libdoc/minitest/unit/rdoc/MiniTest.html
- MiniTest in Ruby 2 https://ruby-doc.org/stdlib-2.0.0/libdoc/minitest/rdoc/MiniTest.html