### PR TITLE
Add support for GitLab CI ENV variable CI_NODE_INDEX starting from 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 * TODO
 
+* Add support for GitLab CI ENV variable CI_NODE_INDEX starting from 1 
+
+    https://github.com/ArturT/knapsack/pull/83
+
 ### 1.16.0
 
 * Add support for Ruby >= 1.9.3.

--- a/lib/knapsack/config/env.rb
+++ b/lib/knapsack/config/env.rb
@@ -11,7 +11,7 @@ module Knapsack
         end
 
         def ci_node_index
-          ENV['CI_NODE_INDEX'] || ENV['CIRCLE_NODE_INDEX'] || semaphore_current_thread || ENV['BUILDKITE_PARALLEL_JOB'] || snap_ci_worker_index || 0
+          gitlab_ci_node_index || ENV['CI_NODE_INDEX'] || ENV['CIRCLE_NODE_INDEX'] || semaphore_current_thread || ENV['BUILDKITE_PARALLEL_JOB'] || snap_ci_worker_index || 0
         end
 
         def test_file_pattern
@@ -42,6 +42,12 @@ module Knapsack
 
         def snap_ci_worker_index
           index_starting_from_one(ENV['SNAP_WORKER_INDEX'])
+        end
+
+        def gitlab_ci_node_index
+          return unless ENV['GITLAB_CI']
+
+          index_starting_from_one(ENV['CI_NODE_INDEX'])
         end
       end
     end

--- a/spec/knapsack/config/env_spec.rb
+++ b/spec/knapsack/config/env_spec.rb
@@ -57,6 +57,11 @@ describe Knapsack::Config::Env do
         it { should eql 3 }
       end
 
+      context 'when CI_NODE_INDEX has value and is in GitLab CI' do
+        before { stub_const("ENV", { 'CI_NODE_INDEX' => 3, 'GITLAB_CI' => 'true' }) }
+        it { should eql 2 }
+      end
+
       context 'when CIRCLE_NODE_INDEX has value' do
         before { stub_const("ENV", { 'CIRCLE_NODE_INDEX' => 2 }) }
         it { should eql 2 }


### PR DESCRIPTION
Since GitLab 11.5, you can define `parallel: x` (2 to 50) to a job and have it
run in multiple workers. You no longer need to define all of them
nor define any environmental variable manually.

You can read more from the documentation here:
https://docs.gitlab.com/ee/ci/yaml/#parallel

You can read about pre-defined ENV variables in GitLab CI here:
https://docs.gitlab.com/ee/ci/variables/README.html#predefined-variables-environment-variables