### PR TITLE
Fix signal handling by replacing process

### DIFF
--- a/lib/knapsack/runners/rspec_runner.rb
+++ b/lib/knapsack/runners/rspec_runner.rb
@@ -14,8 +14,7 @@ module Knapsack
 
         cmd = %Q[bundle exec rspec #{args} --default-path #{allocator.test_dir} -- #{allocator.stringify_node_tests}]
 
-        system(cmd)
-        exit($?.exitstatus) unless $?.exitstatus == 0
+        exec(cmd)
       end
     end
   end


### PR DESCRIPTION
Fixes #85 
rspec handles signals properly so instead of calling rspec as subprocess current process is replaced with rspec and make the current process signals aware