### PR TITLE
Add support for Semaphore 2.0

### DIFF
--- a/lib/knapsack/config/env.rb
+++ b/lib/knapsack/config/env.rb
@@ -7,11 +7,11 @@ module Knapsack
         end
 
         def ci_node_total
-          ENV['CI_NODE_TOTAL'] || ENV['CIRCLE_NODE_TOTAL'] || ENV['SEMAPHORE_THREAD_COUNT'] || ENV['BUILDKITE_PARALLEL_JOB_COUNT'] || ENV['SNAP_WORKER_TOTAL'] || 1
+          ENV['CI_NODE_TOTAL'] || ENV['CIRCLE_NODE_TOTAL'] || ENV['SEMAPHORE_JOB_COUNT'] || ENV['SEMAPHORE_THREAD_COUNT'] || ENV['BUILDKITE_PARALLEL_JOB_COUNT'] || ENV['SNAP_WORKER_TOTAL'] || 1
         end
 
         def ci_node_index
-          gitlab_ci_node_index || ENV['CI_NODE_INDEX'] || ENV['CIRCLE_NODE_INDEX'] || semaphore_current_thread || ENV['BUILDKITE_PARALLEL_JOB'] || snap_ci_worker_index || 0
+          gitlab_ci_node_index || ENV['CI_NODE_INDEX'] || ENV['CIRCLE_NODE_INDEX'] || semaphore_job_index || semaphore_current_thread || ENV['BUILDKITE_PARALLEL_JOB'] || snap_ci_worker_index || 0
         end
 
         def test_file_pattern
@@ -34,6 +34,10 @@ module Knapsack
 
         def index_starting_from_one(index)
           index.to_i - 1 if index
+        end
+
+        def semaphore_job_index
+          index_starting_from_one(ENV['SEMAPHORE_JOB_INDEX'])
         end
 
         def semaphore_current_thread

--- a/spec/knapsack/config/env_spec.rb
+++ b/spec/knapsack/config/env_spec.rb
@@ -27,6 +27,11 @@ describe Knapsack::Config::Env do
         it { should eql 4 }
       end
 
+      context 'when SEMAPHORE_JOB_COUNT has value' do
+        before { stub_const("ENV", { 'SEMAPHORE_JOB_COUNT' => 3 }) }
+        it { should eql 3 }
+      end
+
       context 'when SEMAPHORE_THREAD_COUNT has value' do
         before { stub_const("ENV", { 'SEMAPHORE_THREAD_COUNT' => 3 }) }
         it { should eql 3 }
@@ -64,6 +69,11 @@ describe Knapsack::Config::Env do
 
       context 'when CIRCLE_NODE_INDEX has value' do
         before { stub_const("ENV", { 'CIRCLE_NODE_INDEX' => 2 }) }
+        it { should eql 2 }
+      end
+
+      context 'when SEMAPHORE_JOB_INDEX has value' do
+        before { stub_const("ENV", { 'SEMAPHORE_JOB_INDEX' => 3 }) }
         it { should eql 2 }
       end
 


### PR DESCRIPTION
This adds support for the new count/index environment variables used in Semaphore 2.0's jobs (previously, "threads"), per https://docs.semaphoreci.com/article/50-pipeline-yaml#parallelism

@ArturT I've left `CHANGELOG.md` untouched - let me know if you'd like me to append to it prior to merge, or if that's something you'd rather handle.

Thanks!