### PR TITLE
Use Process.clock_gettime to measure track execution time

### DIFF
--- a/lib/knapsack/tracker.rb
+++ b/lib/knapsack/tracker.rb
@@ -81,11 +81,7 @@ module Knapsack
     end
 
     def now_without_mock_time
-      if defined?(Timecop)
-        Time.now_without_mock_time
-      else
-        Time.raw_now
-      end
+      Process.clock_gettime(Process::CLOCK_MONOTONIC)
     end
   end
 end


### PR DESCRIPTION
Using any variation of `Time.now` is not a reliable way of measuring elapsed time. It may be affected by jumps in local clock. Instead we can use a more reliable `Process.clock_gettime(Process::CLOCK_MONOTINIC)`.

I've removed a `Timecop` dependency from the production code, but left it in the tests to check that a new solution works correctly with Timecop.

For detailed explaination, please read this excellent blogpost: https://blog.dnsimple.com/2018/03/elapsed-time-with-ruby-the-right-way/